### PR TITLE
Add address cleaner script with tests

### DIFF
--- a/address_cleaner.py
+++ b/address_cleaner.py
@@ -1,0 +1,23 @@
+import re
+
+FOOTER_ADDRESS_PATTERN = re.compile(r',[^<]*(?=$|<br>|</p>)', re.IGNORECASE)
+
+def clean_footer_address(text: str) -> str:
+    """Remove trailing city/country from footer address lines.
+
+    Examples:
+        >>> clean_footer_address('<li>info@example.com, Dubai, UAE</li>')
+        '<li>info@example.com</li>'
+    """
+    return FOOTER_ADDRESS_PATTERN.sub('', text, count=1)
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        for path in sys.argv[1:]:
+            with open(path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            cleaned = clean_footer_address(content)
+            print(cleaned)
+    else:
+        print(clean_footer_address(sys.stdin.read()))

--- a/tests/test_address_cleaner.py
+++ b/tests/test_address_cleaner.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from address_cleaner import clean_footer_address
+
+
+def test_remove_after_comma_before_br():
+    inp = '<p>123 Mindset Avenue, Suite 456<br>New York, NY 10001</p>'
+    expected = '<p>123 Mindset Avenue<br>New York, NY 10001</p>'
+    assert clean_footer_address(inp) == expected
+
+
+def test_remove_after_comma_before_p_close():
+    inp = '<p>Email us at info@example.com, Dubai, UAE</p>'
+    expected = '<p>Email us at info@example.com</p>'
+    assert clean_footer_address(inp) == expected
+
+
+def test_remove_city_country_alone():
+    text = '<p>Dubai, UAE</p>'
+    assert clean_footer_address(text) == '<p>Dubai</p>'


### PR DESCRIPTION
## Summary
- add `address_cleaner.py` to strip city/country text from footer lines
- add pytest covering common footer address formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2b0675cc8324b3f6e86fcd616b58