### PR TITLE
Remove pricing sections from services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -148,7 +148,6 @@
                     </div>
                     
                     <div class="mb-6">
-                        <div class="text-3xl font-head font-bold text-navy mb-2">$1,200</div>
                         <div class="text-gray-500">6-week program</div>
                     </div>
                     
@@ -179,7 +178,6 @@
                     </div>
                     
                     <div class="mb-6">
-                        <div class="text-3xl font-head font-bold text-porcelain mb-2">$2,400</div>
                         <div class="text-porcelain opacity-70">12-week program</div>
                     </div>
                     
@@ -208,7 +206,6 @@
                     </div>
                     
                     <div class="mb-6">
-                        <div class="text-3xl font-head font-bold text-navy mb-2">$800</div>
                         <div class="text-gray-500">4-week program</div>
                     </div>
                     
@@ -274,42 +271,36 @@
                 <div class="bg-porcelain rounded-2xl p-6">
                     <h3 class="font-head font-bold text-xl text-navy mb-3">Team Workshops</h3>
                     <p class="text-gray-600 mb-4">Customized workshops for teams and organizations looking to improve collective performance.</p>
-                    <div class="text-2xl font-head font-bold text-navy mb-2">$2,500</div>
                     <div class="text-gray-500 text-sm">Per workshop (up to 20 participants)</div>
                 </div>
                 
                 <div class="bg-porcelain rounded-2xl p-6">
                     <h3 class="font-head font-bold text-xl text-navy mb-3">Executive Coaching</h3>
                     <p class="text-gray-600 mb-4">Intensive one-on-one coaching for C-level executives and senior leaders.</p>
-                    <div class="text-2xl font-head font-bold text-navy mb-2">$500</div>
                     <div class="text-gray-500 text-sm">Per session (90 minutes)</div>
                 </div>
                 
                 <div class="bg-porcelain rounded-2xl p-6">
                     <h3 class="font-head font-bold text-xl text-navy mb-3">Ongoing Support</h3>
                     <p class="text-gray-600 mb-4">Monthly check-ins and support to maintain momentum after completing a program.</p>
-                    <div class="text-2xl font-head font-bold text-navy mb-2">$200</div>
                     <div class="text-gray-500 text-sm">Per month</div>
                 </div>
                 
                 <div class="bg-porcelain rounded-2xl p-6">
                     <h3 class="font-head font-bold text-xl text-navy mb-3">Assessment Tools</h3>
                     <p class="text-gray-600 mb-4">Comprehensive personality and performance assessments to deepen self-awareness.</p>
-                    <div class="text-2xl font-head font-bold text-navy mb-2">$150</div>
                     <div class="text-gray-500 text-sm">Per assessment</div>
                 </div>
                 
                 <div class="bg-porcelain rounded-2xl p-6">
                     <h3 class="font-head font-bold text-xl text-navy mb-3">Custom Programs</h3>
                     <p class="text-gray-600 mb-4">Tailored coaching programs designed specifically for your unique needs and goals.</p>
-                    <div class="text-2xl font-head font-bold text-navy mb-2">Custom</div>
                     <div class="text-gray-500 text-sm">Contact for pricing</div>
                 </div>
                 
                 <div class="bg-porcelain rounded-2xl p-6">
                     <h3 class="font-head font-bold text-xl text-navy mb-3">Speaking Engagements</h3>
                     <p class="text-gray-600 mb-4">Keynote speeches and presentations for conferences, events, and corporate gatherings.</p>
-                    <div class="text-2xl font-head font-bold text-navy mb-2">$5,000</div>
                     <div class="text-gray-500 text-sm">Per engagement</div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove price amounts across main services
- strip price text from add-on services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e30f133008324ab51dbacb23ab63d