### PR TITLE
Add automated translation quality checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "ashourmindset-site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ashourmindset-site",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.3.1",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ashourmindset-site",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "node-fetch": "^2.6.7"
+  }
+}

--- a/test/checkTranslations.js
+++ b/test/checkTranslations.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const { rateTranslation } = require('./utils/rateTranslation');
+
+const LOCALES_DIR = path.join(__dirname, '..', 'i18n');
+const PLACEHOLDERS = new Set(['TODO', 'TBD', '...', '—']);
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function collectKeys(obj, prefix = '') {
+  let keys = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object') {
+      keys = keys.concat(collectKeys(v, key));
+    } else {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+function getValue(obj, key) {
+  return key.split('.').reduce((o, k) => (o ? o[k] : undefined), obj);
+}
+
+(async function main() {
+  const files = fs.readdirSync(LOCALES_DIR).filter(f => f.endsWith('.json'));
+  const locales = files.map(f => path.basename(f, '.json'));
+  const data = {};
+  for (const f of files) {
+    data[path.basename(f, '.json')] = readJson(path.join(LOCALES_DIR, f));
+  }
+
+  const en = data.en;
+  if (!en) {
+    console.error('Missing en.json');
+    process.exit(1);
+  }
+
+  // Phase 1: key parity
+  const enKeys = collectKeys(en);
+  let parityFailed = false;
+  for (const locale of locales) {
+    const keys = collectKeys(data[locale]);
+    const missing = enKeys.filter(k => !keys.includes(k));
+    const extra = keys.filter(k => !enKeys.includes(k));
+    if (missing.length || extra.length) {
+      parityFailed = true;
+      console.error(`Key mismatch for ${locale}: missing ${missing.length}, extra ${extra.length}`);
+    }
+  }
+
+  // Phase 2: placeholder/empty/identical checks
+  let placeholderFailed = false;
+  for (const locale of locales) {
+    if (locale === 'en') continue;
+    for (const key of enKeys) {
+      const source = getValue(en, key);
+      const target = getValue(data[locale], key);
+      if (target === undefined) continue; // handled in parity
+      if (!target || target.trim() === '' || PLACEHOLDERS.has(target.trim()) || target.trim() === source.trim()) {
+        placeholderFailed = true;
+        console.error(`Bad translation for ${locale}.${key}: "${target}"`);
+      }
+    }
+  }
+
+  // Phase 3: quality sampling using OpenAI
+  let qualityFailed = false;
+  const worst = [];
+  for (const locale of locales) {
+    if (locale === 'en') continue;
+    const pairs = enKeys.map(key => ({key, source: getValue(en, key), target: getValue(data[locale], key)}));
+    const sample = pairs.sort(() => Math.random() - 0.5).slice(0, 40);
+    const results = await Promise.all(sample.map(p => rateTranslation(p.source, p.target).then(score => ({...p, score})).catch(err => ({...p, score:0, error: err.message}))));
+    results.sort((a,b)=>a.score-b.score);
+    worst.push(...results.slice(0, 5).map(r => ({locale, key: r.key, score: r.score.toFixed(2), source: r.source, target: r.target})));
+    const bad = results.filter(r => r.score < 0.7).length;
+    if (bad > results.length * 0.2) {
+      qualityFailed = true;
+      console.error(`Poor translation quality detected for ${locale}: ${bad}/${results.length} below 0.70`);
+    }
+  }
+
+  if (worst.length) {
+    console.table(worst.sort((a,b)=>a.score-b.score));
+  }
+
+  if (parityFailed || placeholderFailed || qualityFailed) {
+    process.exit(1);
+  }
+  console.log('All translations look good!');
+})();

--- a/test/utils/rateTranslation.js
+++ b/test/utils/rateTranslation.js
@@ -1,0 +1,66 @@
+let fetchFn = global.fetch;
+if (!fetchFn) {
+  try {
+    fetchFn = require('node-fetch');
+  } catch (err) {
+    throw new Error('Fetch API not available and node-fetch not installed');
+  }
+}
+const fetch = fetchFn;
+require('dotenv').config();
+
+// Simple concurrency limiter
+const concurrency = 5;
+const queue = [];
+let active = 0;
+
+function run(fn) {
+  return new Promise((resolve, reject) => {
+    queue.push({fn, resolve, reject});
+    next();
+  });
+}
+
+function next() {
+  if (active >= concurrency || queue.length === 0) return;
+  const {fn, resolve, reject} = queue.shift();
+  active++;
+  fn().then(resolve, reject).finally(() => {
+    active--;
+    next();
+  });
+}
+
+async function callOpenAI(source, target) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('Missing OPENAI_API_KEY');
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {role: 'system', content: 'You evaluate translation quality.'},
+        {role: 'user', content: `Rate from 0 to 1 how well the following target text translates the source text. Respond only with the number.\nSource: "${source}"\nTarget: "${target}"`}
+      ],
+      temperature: 0
+    })
+  });
+
+  const data = await response.json();
+  const text = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+  const match = text && text.match(/\d*\.?\d+/);
+  const score = match ? parseFloat(match[0]) : NaN;
+  if (isNaN(score)) throw new Error('Invalid score from OpenAI');
+  return Math.max(0, Math.min(1, score));
+}
+
+function rateTranslation(source, target) {
+  return run(() => callOpenAI(source, target));
+}
+
+module.exports = { rateTranslation };


### PR DESCRIPTION
## Summary
- add OpenAI-powered translation checker script under `test/`
- add concurrency-throttled helper for rating translations
- add `package.json` with required dependencies

## Testing
- `pytest -q`
- `OPENAI_API_KEY=sk-test node test/checkTranslations.js` *(fails because of dummy key)*

------
https://chatgpt.com/codex/tasks/task_e_687e3bb48bb08324ad787a00ce828eac