### PR TITLE
Move translation checker to scripts folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For technical support or customization requests, refer to the included `WEBSITE_
 
 ```bash
 # run full lint (requires OPENAI_API_KEY)
-node test/checkTranslations.js
+node scripts/checkTranslations.js
 ```
 
 This script validates that all translation files are aligned. Ensure you have a

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "dotenv": "^16.0.0"
   },
   "scripts": {
-    "lint:translations": "node test/checkTranslations.js"
+    "lint:translations": "node scripts/checkTranslations.js"
   }
 }

--- a/scripts/checkTranslations.js
+++ b/scripts/checkTranslations.js
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+
+const i18nDir = path.resolve('i18n');
+const files = ['en.json', 'de.json', 'ar.json'];
+
+function loadJSON(file) {
+  return JSON.parse(fs.readFileSync(path.join(i18nDir, file), 'utf8'));
+}
+
+function getKeys(obj, prefix = '') {
+  let keys = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === 'object' && v !== null) {
+      keys = keys.concat(getKeys(v, fullKey));
+    } else {
+      keys.push(fullKey);
+    }
+  }
+  return keys;
+}
+
+function compareKeys(baseKeys, otherKeys, lang) {
+  const missing = baseKeys.filter(k => !otherKeys.includes(k));
+  const extra = otherKeys.filter(k => !baseKeys.includes(k));
+  if (missing.length || extra.length) {
+    console.log(`\nIssues found in ${lang}:`);
+    if (missing.length) console.log('  Missing keys:', missing.join(', '));
+    if (extra.length) console.log('  Extra keys:', extra.join(', '));
+    return true;
+  }
+  return false;
+}
+
+function main() {
+  const data = files.map(f => loadJSON(f));
+  const baseKeys = getKeys(data[0]);
+  let hasIssues = false;
+  for (let i = 1; i < data.length; i++) {
+    const keys = getKeys(data[i]);
+    if (compareKeys(baseKeys, keys, files[i])) {
+      hasIssues = true;
+    }
+  }
+  if (hasIssues) {
+    console.error('\nTranslation files are inconsistent.');
+    process.exitCode = 1;
+  } else {
+    console.log('All translation files have consistent keys.');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add scripts folder and move translation checker there
- update package.json script path
- document new scripts path in README

## Testing
- `pytest -q tests/test_address_cleaner.py`
- `npm run lint:translations`


------
https://chatgpt.com/codex/tasks/task_e_687e403b1ac083248936a2cb0423843e