### PR TITLE
Handle missing OpenAI key in translation check

### DIFF
--- a/test/checkTranslations.js
+++ b/test/checkTranslations.js
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import rateTranslation from './rateTranslation.js';
+
+// Load environment variables from .env if present
+dotenv.config();
+
+const LOCALES_DIR = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'i18n');
+const baseLang = 'en';
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function diffKeys(base, compare) {
+  const missing = [];
+  for (const key of Object.keys(base)) {
+    if (!(key in compare)) missing.push(key);
+  }
+  const extra = [];
+  for (const key of Object.keys(compare)) {
+    if (!(key in base)) extra.push(key);
+  }
+  return { missing, extra };
+}
+
+function phase1() {
+  const basePath = path.join(LOCALES_DIR, `${baseLang}.json`);
+  const baseData = readJson(basePath);
+
+  const files = fs.readdirSync(LOCALES_DIR).filter(f => f.endsWith('.json') && f !== `${baseLang}.json`);
+  let ok = true;
+  for (const file of files) {
+    const data = readJson(path.join(LOCALES_DIR, file));
+    const diff = diffKeys(baseData, data);
+    if (diff.missing.length || diff.extra.length) {
+      console.error(`\n[${file}] key mismatch:`);
+      if (diff.missing.length) console.error('  missing:', diff.missing.join(', '));
+      if (diff.extra.length) console.error('  extra:', diff.extra.join(', '));
+      ok = false;
+    }
+  }
+  return ok;
+}
+
+async function phase3() {
+  const baseData = readJson(path.join(LOCALES_DIR, `${baseLang}.json`));
+  const files = fs.readdirSync(LOCALES_DIR).filter(f => f.endsWith('.json') && f !== `${baseLang}.json`);
+  for (const file of files) {
+    const lang = path.basename(file, '.json');
+    const data = readJson(path.join(LOCALES_DIR, file));
+    for (const key of Object.keys(baseData)) {
+      if (typeof data[key] === 'string') {
+        const rating = await rateTranslation(baseData[key], data[key], lang);
+        console.log(`${lang}:${key}: ${rating}`);
+      }
+    }
+  }
+}
+
+async function main() {
+  const ok = phase1();
+  if (!ok) {
+    console.error('Translation consistency check failed.');
+    process.exitCode = 1;
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.log('Skipping Phase 3: no OPENAI_API_KEY provided');
+    return;
+  }
+
+  try {
+    await phase3();
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/test/rateTranslation.js
+++ b/test/rateTranslation.js
@@ -1,0 +1,19 @@
+import OpenAI from 'openai';
+
+export default async function rateTranslation(source, candidate, language) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY is required');
+  }
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const prompt = `Evaluate the quality of this ${language} translation. Rate on a scale of 1-5 and briefly justify.`;
+  const messages = [
+    { role: 'system', content: prompt },
+    { role: 'user', content: `English: ${source}\nTranslation: ${candidate}` }
+  ];
+  const res = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages,
+    max_tokens: 10
+  });
+  return res.choices[0].message.content.trim();
+}


### PR DESCRIPTION
## Summary
- add translation consistency test script
- include rating helper using OpenAI
- skip Phase 3 when `OPENAI_API_KEY` isn't present

## Testing
- `npm install`
- `node test/checkTranslations.js`
- `node -e "import('./test/rateTranslation.js').then(m=>m.default('hi','hola','es')).catch(e=>console.error('ERR:'+e.message))"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e403969588324ba71e0cc350cf938