### PR TITLE
Fix services FAQ accordion markup

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -297,29 +297,29 @@
             </div>
             
             <div class="max-w-4xl mx-auto space-y-6">
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">How do I schedule a free consultation?</h3>
-                    <p class="text-gray-600">Simply fill out the contact form above or send an email directly. We'll respond within 24 to 48 hours to schedule your 30-minute discovery call.</p>
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">How do I schedule a free consultation?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Simply fill out the contact form above or send an email directly. We'll respond within 24 to 48 hours to schedule your 30-minute discovery call.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">Do you offer virtual coaching sessions?</h3>
-                    <p class="text-gray-600">Yes! All our coaching services are available both in-person and virtually via secure video conferencing. Many clients prefer the convenience of virtual sessions.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">Do you offer virtual coaching sessions?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Yes! All our coaching services are available both in-person and virtually via secure video conferencing. Many clients prefer the convenience of virtual sessions.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">What information should I include in my message?</h3>
-                    <p class="text-gray-600">Please share your current challenges, goals, and what you hope to achieve through coaching. The more specific you are, the better we can tailor our initial conversation to your needs.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">What information should I include in my message?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Please share your current challenges, goals, and what you hope to achieve through coaching. The more specific you are, the better we can tailor our initial conversation to your needs.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">How quickly can I start a coaching program?</h3>
-                    <p class="text-gray-600">Depending on availability and your preferred timeline, most clients can begin their coaching journey within 1-2 weeks of their initial consultation.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">How quickly can I start a coaching program?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Depending on availability and your preferred timeline, most clients can begin their coaching journey within 1-2 weeks of their initial consultation.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">Do you offer payment plans?</h3>
-                    <p class="text-gray-600">Yes, we offer flexible payment options including monthly installments for all our programs. We'll discuss payment options during the consultation.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">Do you offer payment plans?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Yes, we offer flexible payment options including monthly installments for all our programs. We'll discuss payment options during the consultation.</p>
                 </div>
             </div>
         </div>

--- a/services.html
+++ b/services.html
@@ -316,29 +316,29 @@
             </div>
             
             <div class="max-w-4xl mx-auto space-y-6">
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">How long does it take to see results?</h3>
-                    <p class="text-gray-600">Most clients begin to notice positive changes within the first 2-3 weeks of coaching. Significant transformation typically occurs within 6-12 weeks, depending on the program and individual commitment level.</p>
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">How long does it take to see results?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Most clients begin to notice positive changes within the first 2-3 weeks of coaching. Significant transformation typically occurs within 6-12 weeks, depending on the program and individual commitment level.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">What makes your approach different?</h3>
-                    <p class="text-gray-600">Our methodology combines proven psychological principles with data-driven insights and practical implementation strategies. We focus on measurable outcomes and sustainable change rather than temporary motivation.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">What makes your approach different?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Our methodology combines proven psychological principles with data-driven insights and practical implementation strategies. We focus on measurable outcomes and sustainable change rather than temporary motivation.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">Do you offer payment plans?</h3>
-                    <p class="text-gray-600">Yes, we offer flexible payment options including monthly installments for all our programs. Contact us to discuss a payment plan that works for your budget.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">Do you offer payment plans?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Yes, we offer flexible payment options including monthly installments for all our programs. Contact us to discuss a payment plan that works for your budget.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">Can coaching be done remotely?</h3>
-                    <p class="text-gray-600">Absolutely! All our coaching services are available both in-person and virtually via video conferencing. Many clients prefer the convenience and flexibility of remote sessions.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">Can coaching be done remotely?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">Absolutely! All our coaching services are available both in-person and virtually via video conferencing. Many clients prefer the convenience and flexibility of remote sessions.</p>
                 </div>
-                
-                <div class="bg-white rounded-2xl p-6">
-                    <h3 class="font-head font-bold text-xl text-navy mb-3">What if I'm not satisfied with the results?</h3>
-                    <p class="text-gray-600">We offer a 30-day satisfaction guarantee. If you're not completely satisfied with your progress after the first month, we'll work with you to adjust the approach or provide a full refund.</p>
+
+                <div class="faq-item bg-white rounded-2xl p-6">
+                    <h3 class="faq-question font-head font-bold text-xl text-navy mb-3">What if I'm not satisfied with the results?</h3>
+                    <p class="faq-answer text-gray-600" style="display:none;">We offer a 30-day satisfaction guarantee. If you're not completely satisfied with your progress after the first month, we'll work with you to adjust the approach or provide a full refund.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add proper `.faq-item`, `.faq-question`, and `.faq-answer` classes in FAQ sections
- hide answers by default so JS accordion script can toggle them

## Testing
- `pytest -q`
- `node test/checkTranslations.js`


------
https://chatgpt.com/codex/tasks/task_e_687f5b015df08324b6851bb58fddf5b6