### PR TITLE
Remove navigation link to Contact page

### DIFF
--- a/about.html
+++ b/about.html
@@ -88,7 +88,6 @@
                     <li><a href="about.html" class="text-coral" data-translate="nav.about">About</a></li>
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                    <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
                 </ul>
                 <div class="relative nav-item">
                     <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
@@ -118,7 +117,6 @@
                 <li><a href="about.html" class="text-coral" data-translate="nav.about">About</a></li>
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
             </ul>
         </div>
     </nav>

--- a/blog.html
+++ b/blog.html
@@ -88,7 +88,6 @@
                     <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                    <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
                 </ul>
                 <div class="relative nav-item">
                     <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
@@ -118,7 +117,6 @@
                 <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
             </ul>
         </div>
     </nav>

--- a/contact.html
+++ b/contact.html
@@ -88,7 +88,6 @@
                     <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                    <li><a href="contact.html" class="text-coral" data-translate="nav.contact">Contact</a></li>
                 </ul>
                 <div class="relative nav-item">
                     <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
@@ -118,7 +117,6 @@
                 <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                <li><a href="contact.html" class="text-coral" data-translate="nav.contact">Contact</a></li>
             </ul>
         </div>
     </nav>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,6 @@
                     <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                    <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
                 </ul>
                 <div class="relative nav-item">
                     <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
@@ -123,7 +122,6 @@
                 <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
             </ul>
         </div>
     </nav>

--- a/services.html
+++ b/services.html
@@ -88,7 +88,6 @@
                     <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                     <li><a href="services.html" class="text-coral" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                    <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
                 </ul>
                 <div class="relative nav-item">
                     <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
@@ -118,7 +117,6 @@
                 <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                 <li><a href="services.html" class="text-coral" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
-                <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
             </ul>
         </div>
     </nav>

--- a/testimonials.html
+++ b/testimonials.html
@@ -88,7 +88,6 @@
                     <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="text-coral" data-translate="nav.testimonials">Testimonials</a></li>
-                    <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
                 </ul>
                 <div class="relative nav-item">
                     <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
@@ -118,7 +117,6 @@
                 <li><a href="about.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.about">About</a></li>
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="text-coral" data-translate="nav.testimonials">Testimonials</a></li>
-                <li><a href="contact.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.contact">Contact</a></li>
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- remove Contact page from the main navigation across all pages
- keep footer link for Contact

## Testing
- `pytest -q`
- `npm run lint:translations`

------
https://chatgpt.com/codex/tasks/task_e_687f6be5ca748324be49ca640fc93acd