### PR TITLE
Place language selector inside mobile menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -89,8 +89,8 @@
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
                 </ul>
-                <div class="relative nav-item">
-                    <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                <div class="relative nav-item hidden md:block">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
                         <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
                         <span>EN</span>
                     </button>
@@ -118,6 +118,28 @@
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
             </ul>
+            <div class="p-4 flex justify-center md:hidden">
+                <div class="relative nav-item">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                        <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                        <span>EN</span>
+                    </button>
+                    <div class="dropdown-panel absolute right-0 mt-2 w-32 text-left">
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="en">
+                            <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                            <span>English</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="de">
+                            <img src="assets/icons/germany-flag.png" alt="German" class="w-4 h-4 rounded-full">
+                            <span>Deutsch</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="ar">
+                            <img src="assets/icons/egypt-flag.png" alt="Arabic" class="w-4 h-4 rounded-full">
+                            <span>العربية</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </nav>
 

--- a/blog.html
+++ b/blog.html
@@ -89,8 +89,8 @@
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
                 </ul>
-                <div class="relative nav-item">
-                    <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                <div class="relative nav-item hidden md:block">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
                         <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
                         <span>EN</span>
                     </button>
@@ -118,6 +118,28 @@
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
             </ul>
+            <div class="p-4 flex justify-center md:hidden">
+                <div class="relative nav-item">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                        <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                        <span>EN</span>
+                    </button>
+                    <div class="dropdown-panel absolute right-0 mt-2 w-32 text-left">
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="en">
+                            <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                            <span>English</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="de">
+                            <img src="assets/icons/germany-flag.png" alt="German" class="w-4 h-4 rounded-full">
+                            <span>Deutsch</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="ar">
+                            <img src="assets/icons/egypt-flag.png" alt="Arabic" class="w-4 h-4 rounded-full">
+                            <span>العربية</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </nav>
 

--- a/contact.html
+++ b/contact.html
@@ -89,8 +89,8 @@
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
                 </ul>
-                <div class="relative nav-item">
-                    <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                <div class="relative nav-item hidden md:block">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
                         <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
                         <span>EN</span>
                     </button>
@@ -118,6 +118,28 @@
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
             </ul>
+            <div class="p-4 flex justify-center md:hidden">
+                <div class="relative nav-item">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                        <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                        <span>EN</span>
+                    </button>
+                    <div class="dropdown-panel absolute right-0 mt-2 w-32 text-left">
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="en">
+                            <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                            <span>English</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="de">
+                            <img src="assets/icons/germany-flag.png" alt="German" class="w-4 h-4 rounded-full">
+                            <span>Deutsch</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="ar">
+                            <img src="assets/icons/egypt-flag.png" alt="Arabic" class="w-4 h-4 rounded-full">
+                            <span>العربية</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </nav>
 

--- a/index.html
+++ b/index.html
@@ -94,8 +94,8 @@
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
                 </ul>
-                <div class="relative nav-item">
-                    <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                <div class="relative nav-item hidden md:block">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
                         <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
                         <span>EN</span>
                     </button>
@@ -123,6 +123,28 @@
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
             </ul>
+            <div class="p-4 flex justify-center md:hidden">
+                <div class="relative nav-item">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                        <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                        <span>EN</span>
+                    </button>
+                    <div class="dropdown-panel absolute right-0 mt-2 w-32 text-left">
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="en">
+                            <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                            <span>English</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="de">
+                            <img src="assets/icons/germany-flag.png" alt="German" class="w-4 h-4 rounded-full">
+                            <span>Deutsch</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="ar">
+                            <img src="assets/icons/egypt-flag.png" alt="Arabic" class="w-4 h-4 rounded-full">
+                            <span>العربية</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </nav>
 

--- a/services.html
+++ b/services.html
@@ -89,8 +89,8 @@
                     <li><a href="services.html" class="text-coral" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
                 </ul>
-                <div class="relative nav-item">
-                    <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                <div class="relative nav-item hidden md:block">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
                         <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
                         <span>EN</span>
                     </button>
@@ -118,6 +118,28 @@
                 <li><a href="services.html" class="text-coral" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.testimonials">Testimonials</a></li>
             </ul>
+            <div class="p-4 flex justify-center md:hidden">
+                <div class="relative nav-item">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                        <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                        <span>EN</span>
+                    </button>
+                    <div class="dropdown-panel absolute right-0 mt-2 w-32 text-left">
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="en">
+                            <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                            <span>English</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="de">
+                            <img src="assets/icons/germany-flag.png" alt="German" class="w-4 h-4 rounded-full">
+                            <span>Deutsch</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="ar">
+                            <img src="assets/icons/egypt-flag.png" alt="Arabic" class="w-4 h-4 rounded-full">
+                            <span>العربية</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </nav>
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,11 +26,11 @@ document.addEventListener("DOMContentLoaded", function() {
         });
         
         // Update language switcher with flag and text
-        const langSwitcher = document.getElementById('lang-switcher');
-        if (langSwitcher) {
+        const langSwitchers = document.querySelectorAll('.lang-switcher');
+        langSwitchers.forEach(langSwitcher => {
             const flagImg = langSwitcher.querySelector('img');
             const textSpan = langSwitcher.querySelector('span');
-            
+
             if (flagImg && textSpan) {
                 switch(currentLanguage) {
                     case 'en':
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", function() {
                         break;
                 }
             }
-        }
+        });
         
         // Update document direction for Arabic
         if (currentLanguage === 'ar') {

--- a/testimonials.html
+++ b/testimonials.html
@@ -89,8 +89,8 @@
                     <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                     <li><a href="testimonials.html" class="text-coral" data-translate="nav.testimonials">Testimonials</a></li>
                 </ul>
-                <div class="relative nav-item">
-                    <button id="lang-switcher" class="text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                <div class="relative nav-item hidden md:block">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
                         <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
                         <span>EN</span>
                     </button>
@@ -118,6 +118,28 @@
                 <li><a href="services.html" class="hover:text-coral transition-colors duration-200" data-translate="nav.services">Services</a></li>
                 <li><a href="testimonials.html" class="text-coral" data-translate="nav.testimonials">Testimonials</a></li>
             </ul>
+            <div class="p-4 flex justify-center md:hidden">
+                <div class="relative nav-item">
+                    <button class="lang-switcher text-porcelain hover:text-coral transition-colors duration-200 flex items-center space-x-2">
+                        <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                        <span>EN</span>
+                    </button>
+                    <div class="dropdown-panel absolute right-0 mt-2 w-32 text-left">
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="en">
+                            <img src="assets/icons/uk-flag.png" alt="English" class="w-4 h-4 rounded-full">
+                            <span>English</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="de">
+                            <img src="assets/icons/germany-flag.png" alt="German" class="w-4 h-4 rounded-full">
+                            <span>Deutsch</span>
+                        </a>
+                        <a href="#" class="flex items-center space-x-2 py-2 px-3 hover:text-coral rounded" data-lang-code="ar">
+                            <img src="assets/icons/egypt-flag.png" alt="Arabic" class="w-4 h-4 rounded-full">
+                            <span>العربية</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </nav>
 


### PR DESCRIPTION
## Summary
- show desktop language selector only on larger screens
- replicate language selector inside mobile dropdown
- update JS to target all language switchers
- keep translation tests passing

## Testing
- `pytest -q`
- `node test/checkTranslations.js`

------
https://chatgpt.com/codex/tasks/task_e_68806a948a808324ad8f2b72381c1af3